### PR TITLE
feat: add implement DB migration for queue schema

### DIFF
--- a/database/migrations/20240816190503-createMessageTable.js
+++ b/database/migrations/20240816190503-createMessageTable.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240816190503-createMessageTable-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240816190503-createMessageTable-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/database/migrations/20240816190624-createNotifyFunction.js
+++ b/database/migrations/20240816190624-createNotifyFunction.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240816190624-createNotifyFunction-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240816190624-createNotifyFunction-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/database/migrations/20240816190802-createNewMessageTrigger.js
+++ b/database/migrations/20240816190802-createNewMessageTrigger.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240816190802-createNewMessageTrigger-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240816190802-createNewMessageTrigger-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/database/migrations/sqls/20240816190503-createMessageTable-down.sql
+++ b/database/migrations/sqls/20240816190503-createMessageTable-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+DROP TABLE queue.message;

--- a/database/migrations/sqls/20240816190503-createMessageTable-up.sql
+++ b/database/migrations/sqls/20240816190503-createMessageTable-up.sql
@@ -1,0 +1,11 @@
+/* Replace with your SQL commands */
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE TABLE queue.message (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    channel text,
+    data json,
+    created_at timestamptz,
+    updated_at timestamptz
+);
+ALTER TABLE queue.message ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE queue.message ALTER COLUMN updated_at SET DEFAULT now();

--- a/database/migrations/sqls/20240816190624-createNotifyFunction-down.sql
+++ b/database/migrations/sqls/20240816190624-createNotifyFunction-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+DROP FUNCTION queue.new_message_notify_trigger()

--- a/database/migrations/sqls/20240816190624-createNotifyFunction-up.sql
+++ b/database/migrations/sqls/20240816190624-createNotifyFunction-up.sql
@@ -1,0 +1,8 @@
+/* Replace with your SQL commands */
+CREATE OR REPLACE FUNCTION queue.new_message_notify_trigger() RETURNS TRIGGER AS $$
+            DECLARE
+            BEGIN
+                PERFORM pg_notify(cast(NEW.channel as text), row_to_json(new)::text);
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;

--- a/database/migrations/sqls/20240816190802-createNewMessageTrigger-down.sql
+++ b/database/migrations/sqls/20240816190802-createNewMessageTrigger-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+DROP TRIGGER new_message_insert_trigger on queue.message;

--- a/database/migrations/sqls/20240816190802-createNewMessageTrigger-up.sql
+++ b/database/migrations/sqls/20240816190802-createNewMessageTrigger-up.sql
@@ -1,0 +1,3 @@
+/* Replace with your SQL commands */
+CREATE TRIGGER new_message_insert_trigger BEFORE INSERT ON queue.message
+            FOR EACH ROW EXECUTE PROCEDURE queue.new_message_notify_trigger();


### PR DESCRIPTION
fixes #8 

creates the required message table, schema functions and trigger tables. db-migration tracks actions under `migrations` table under `queue` schema.

`migrations` table
![image](https://github.com/user-attachments/assets/cdc4ce27-5bc0-4dfc-914c-2c57c68b8667)

schema function
![image](https://github.com/user-attachments/assets/39b7ea09-6e2a-4851-8436-90cf4de7663d)

`message` table trigger
![image](https://github.com/user-attachments/assets/12bf02b2-fe80-43b6-89ac-c53dcde4c67c)


